### PR TITLE
fix(executor)

### DIFF
--- a/ocr_pipelines/executor.py
+++ b/ocr_pipelines/executor.py
@@ -3,6 +3,7 @@ import io
 import json
 import logging
 from pathlib import Path
+from openpecha.buda.api import image_group_to_folder_name
 
 from ocr_pipelines.config import ImportConfig
 from ocr_pipelines.engines import register as ocr_engine_class_register
@@ -59,10 +60,11 @@ class OCRExecutor:
         img_group_paths.sort()
         for img_group_path in img_group_paths:
             img_group_id = img_group_path.name
+            img_grp_folder_name = image_group_to_folder_name(bdrc_scan_id, img_group_id)
             ocr_output_dir = (
                 self.config.ocr_outputs_path
                 / bdrc_scan_id
-                / f"{bdrc_scan_id}-{img_group_id}"
+                / img_grp_folder_name
             )
             ocr_output_dir.mkdir(exist_ok=True, parents=True)
             img_paths = list(img_group_path.iterdir())


### PR DESCRIPTION
ocr output path naming has been updated.
After testing the pipeline via a failed case (W21784), i found a bug. The particular case that we have encounter has mainly two issues. Those two issues are the ocr output is completely nonsensical and opf published are not having base. After running test, i found that nonsensical ocr output can be avoided by selecting `builtin-weekly` type model. Regarding the empty base, the ocr output is saved under folder name having whole image group id. Whereas opf formatter look for ocr output it uses a [function](https://github.com/OpenPecha/Toolkit/blob/master/openpecha/formatters/ocr/google_vision.py#L32) of buda api  in openpecha to navigate the folder. Due to this, ocr output are not found hence the empty base in opf. in order to avoid this, the ocr output has been saved under folder following same naming convention as buda api function.